### PR TITLE
Allow overriding config path via $VEIL_CONFIG

### DIFF
--- a/Veil/Config.swift
+++ b/Veil/Config.swift
@@ -216,7 +216,16 @@ struct VeilConfig: Decodable {
     static var current: VeilConfig = load()
 
     static var userConfigPath: URL {
-        FileManager.default.homeDirectoryForCurrentUser
+        // Allow overriding the config location via $VEIL_CONFIG. This lets the
+        // config live somewhere other than the home directory — useful for
+        // immutable/managed setups (e.g. Nix) that point Veil at a generated,
+        // read-only config instead of seeding and editing the default path.
+        if let override = ProcessInfo.processInfo.environment["VEIL_CONFIG"],
+            !override.isEmpty
+        {
+            return URL(fileURLWithPath: (override as NSString).expandingTildeInPath)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/veil/veil.toml")
     }
 


### PR DESCRIPTION
## What

Adds an optional `VEIL_CONFIG` environment variable that overrides the config file location. When set (and non-empty), Veil reads its config from that path (with a leading `~` expanded) instead of the hardcoded `~/.config/veil/veil.toml`. When unset, behavior is unchanged.

```swift
static var userConfigPath: URL {
    if let override = ProcessInfo.processInfo.environment["VEIL_CONFIG"], !override.isEmpty {
        return URL(fileURLWithPath: (override as NSString).expandingTildeInPath)
    }
    return FileManager.default.homeDirectoryForCurrentUser
        .appendingPathComponent(".config/veil/veil.toml")
}
```

## Why

I'm packaging Veil declaratively with Nix/home-manager and pointing it at a *generated, read-only* `veil.toml` (its `nvim_path` is set to a specific wrapped `nvim`). Today the config path is hardcoded to the home directory, and `homeDirectoryForCurrentUser` ignores `$HOME`, so there's no way to point Veil at a managed config without writing into `~/.config/veil`. An env override is the least-invasive way to support immutable/managed setups. It's also handy for testing and for running multiple configs.

Since the value can also be injected into the app bundle's `Info.plist` `LSEnvironment`, this works for GUI launches (Dock/Spotlight/Finder), not just the CLI.

## Notes

- Single-site change; default path and seeding behavior are untouched when the variable is unset.
- Happy to adjust naming or add a test if you'd prefer (I left tests out to avoid touching the Xcode test target's project file without your guidance).